### PR TITLE
fix next event button styling on mobile

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -118,6 +118,13 @@ header {
     max-width: 250px;
   }
 
+
+}
+
+@media (max-width: 767px) {
+  .subhead.callout {
+    display: block;
+  }
 }
 
 


### PR DESCRIPTION
fixes the following button styling:

![screenshot](http://f.cl.ly/items/0K0j103t0b2t0m2g3S0j/Screen%20Shot%202015-06-17%20at%209.08.07%20AM.png)