### PR TITLE
Updated Readme with Mentor list for October 2016

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ nodeschool: LA Edition
 #### To sign up for the next event, please visit: http://nodeschool.io/los-angeles
 
 **Mentors**
-@d48
-TBD
+* @d48 
+* @jcblw 
+* @ashwell
+* @etanlubeck
 
 _If you would like to help mentor at this event, please create a [Pull Request](https://github.com/nodeschool/los-angeles/pulls) and add your name to this list._
 


### PR DESCRIPTION
I've added the mentors from issue https://github.com/nodeschool/los-angeles/issues/92

I'm thinking we might want to remove that last line of the readme since we always do shoutouts for mentors via an issue.